### PR TITLE
Select both image and video with one call to the selector popup

### DIFF
--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,39 +22,47 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vD7-hL-f3u">
-                                <frame key="frameInset" minX="244" minY="99" width="112" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vD7-hL-f3u">
+                                <rect key="frame" x="131" y="127" width="112" height="30"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="112" id="PG2-85-iBV"/>
+                                    <constraint firstAttribute="width" constant="112" id="Kqw-t7-dpm"/>
                                 </constraints>
                                 <state key="normal" title="Select Image"/>
                                 <connections>
                                     <action selector="selectImage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rRm-nJ-Mm2"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Awn-DN-jKk">
-                                <frame key="frameInset" minX="244" minY="137" width="112" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="112" id="TmG-dF-Jcj"/>
-                                </constraints>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Awn-DN-jKk">
+                                <rect key="frame" x="131" y="165" width="112" height="30"/>
                                 <state key="normal" title="Select Video"/>
                                 <connections>
                                     <action selector="selectVideo:" destination="BYZ-38-t0r" eventType="touchUpInside" id="IDR-CU-rcc"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3dL-lg-bEa">
+                                <rect key="frame" x="107" y="203" width="161" height="30"/>
+                                <state key="normal" title="Select Photo or Video"/>
+                                <connections>
+                                    <action selector="selectPhotoOrVideo:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xyh-d0-0PR"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="vD7-hL-f3u" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="0zs-xm-bRE"/>
-                            <constraint firstItem="Awn-DN-jKk" firstAttribute="leading" secondItem="vD7-hL-f3u" secondAttribute="leading" id="7P5-Mg-0ab"/>
-                            <constraint firstItem="Awn-DN-jKk" firstAttribute="top" secondItem="vD7-hL-f3u" secondAttribute="bottom" constant="8" symbolic="YES" id="DG8-iG-wmn"/>
-                            <constraint firstItem="vD7-hL-f3u" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="79" id="oZX-C2-b9L"/>
+                            <constraint firstItem="Awn-DN-jKk" firstAttribute="top" secondItem="vD7-hL-f3u" secondAttribute="bottom" constant="8" symbolic="YES" id="0Su-MN-Uqy"/>
+                            <constraint firstItem="vD7-hL-f3u" firstAttribute="leading" secondItem="Awn-DN-jKk" secondAttribute="leading" id="1Fe-DF-0uS"/>
+                            <constraint firstItem="vD7-hL-f3u" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="493-1H-KXg"/>
+                            <constraint firstItem="3dL-lg-bEa" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="91" id="Jva-8s-8qe"/>
+                            <constraint firstItem="Awn-DN-jKk" firstAttribute="centerX" secondItem="3dL-lg-bEa" secondAttribute="centerX" id="PZZ-LI-PvT"/>
+                            <constraint firstItem="vD7-hL-f3u" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="107" id="XDT-fW-1ed"/>
+                            <constraint firstItem="3dL-lg-bEa" firstAttribute="top" secondItem="Awn-DN-jKk" secondAttribute="bottom" constant="8" symbolic="YES" id="gcN-Qe-abZ"/>
+                            <constraint firstItem="vD7-hL-f3u" firstAttribute="trailing" secondItem="Awn-DN-jKk" secondAttribute="trailing" id="hBX-pI-txV"/>
                         </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="139" y="429"/>
+            <point key="canvasLocation" x="138.40000000000001" y="428.63568215892059"/>
         </scene>
     </scenes>
 </document>

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.6</string>
+	<string>1.2.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -51,6 +51,20 @@ class ViewController: UIViewController {
         mediaSelector.presentingView = sender as? UIView
         mediaSelector.present()
     }
+
+    @IBAction func selectPhotoOrVideo(sender: AnyObject) {
+        mediaSelector.title = "Select Image or Video"
+        mediaSelector.subtitle = "Select among one of these sources"
+        mediaSelector.allowsPhoto = true
+        mediaSelector.allowsVideo = true
+        mediaSelector.allowsEditing = true
+        mediaSelector.videoMaximumDuration = 10
+        mediaSelector.defaultsToFrontCamera = true
+        mediaSelector.buttonBackgroundColor = UIColor.init(white: 0.8, alpha: 1.0)
+        // Required for the iPad
+        mediaSelector.presentingView = sender as? UIView
+        mediaSelector.present()
+    }
     
 }
 

--- a/TLTMediaSelector.podspec
+++ b/TLTMediaSelector.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "TLTMediaSelector"
-  s.version          = "1.2.6"
+  s.version          = "1.2.7"
   s.summary          = "Popover control to select media items such as images"
 
 # This description is used to generate tags and improve search results.

--- a/TLTMediaSelector/Info.plist
+++ b/TLTMediaSelector/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.6</string>
+	<string>1.2.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/TLTMediaSelector/MediaSelection.swift
+++ b/TLTMediaSelector/MediaSelection.swift
@@ -118,7 +118,10 @@ public class MediaSelection: NSObject {
     public var takeVideoText: String? = nil
     
     /// Custom UI text (skips localization)
-    public var chooseFromLibraryText: String? = nil
+    public var chooseFromPhotoLibraryText: String? = nil
+
+    /// Custom UI text (skips localization)
+    public var chooseFromVideoLibraryText: String? = nil
     
     /// Custom UI text (skips localization)
     public var chooseFromPhotoRollText: String? = nil
@@ -138,7 +141,9 @@ public class MediaSelection: NSObject {
     
     private let kTakeVideoKey: String = "takeVideo"
     
-    private let kChooseFromLibraryKey: String = "chooseFromLibrary"
+    private let kChooseFromPhotoLibraryKey: String = "chooseFromPhotoLibrary"
+
+    private let kChooseFromVideoLibraryKey: String = "chooseFromVideoLibrary"
     
     private let kChooseFromPhotoRollKey: String = "chooseFromPhotoRoll"
     
@@ -176,8 +181,10 @@ public class MediaSelection: NSObject {
             return self.takePhotoText ?? "Take Photo"
         case kTakeVideoKey:
             return self.takeVideoText ?? "Take Video"
-        case kChooseFromLibraryKey:
-            return self.chooseFromLibraryText ?? "Use Photo Library"
+        case kChooseFromPhotoLibraryKey:
+            return self.chooseFromPhotoLibraryText ?? "Use Photo Library"
+        case kChooseFromVideoLibraryKey:
+            return self.chooseFromVideoLibraryText ?? "Use Video Library"
         case kChooseFromPhotoRollKey:
             return self.chooseFromPhotoRollText ?? "Use Photo Roll"
         case kCancelKey:
@@ -206,7 +213,12 @@ public class MediaSelection: NSObject {
         }
         if self.allowsSelectFromLibrary {
             if UIImagePickerController.isSourceTypeAvailable(.PhotoLibrary) {
-                titleToSource.append((buttonTitle: kChooseFromLibraryKey, source: .PhotoLibrary))
+                if self.allowsPhoto {
+                    titleToSource.append((buttonTitle: kChooseFromPhotoLibraryKey, source: .PhotoLibrary))
+                }
+                if self.allowsVideo {
+                    titleToSource.append((buttonTitle: kChooseFromVideoLibraryKey, source: .PhotoLibrary))
+                }
             } else if UIImagePickerController.isSourceTypeAvailable(.SavedPhotosAlbum) {
                 titleToSource.append((buttonTitle: kChooseFromPhotoRollKey, source: .SavedPhotosAlbum))
             }
@@ -228,26 +240,16 @@ public class MediaSelection: NSObject {
                     self.imagePicker.cameraDevice = .Front
                 }
                 // set the media type: photo or video
-                self.imagePicker.videoQuality = self.videoQuality
                 var mediaTypes = [String]()
-                if source == UIImagePickerControllerSourceType.PhotoLibrary {
-                    if self.allowsPhoto {
-                        self.imagePicker.allowsEditing = false
-                        mediaTypes.append(String(kUTTypeImage))
-                    }
-                    if self.allowsVideo {
-                        self.imagePicker.allowsEditing = true
-                        self.imagePicker.videoMaximumDuration = self.videoMaximumDuration
-                        mediaTypes.append(String(kUTTypeMovie))
-                    }
+                if title == self.kTakeVideoKey || title == self.kChooseFromVideoLibraryKey {
+                    self.imagePicker.videoQuality = self.videoQuality
+                    self.imagePicker.allowsEditing = self.allowsEditing
+                    self.imagePicker.videoMaximumDuration = self.videoMaximumDuration
+                    mediaTypes.append(String(kUTTypeMovie))
                 }
                 else {
-                    if title == self.kTakeVideoKey {
-                        mediaTypes.append(String(kUTTypeMovie))
-                    }
-                    else {
-                        mediaTypes.append(String(kUTTypeImage))
-                    }
+                    self.imagePicker.allowsEditing = false
+                    mediaTypes.append(String(kUTTypeImage))
                 }
                 self.imagePicker.mediaTypes = mediaTypes
 


### PR DESCRIPTION
As allowsEditing will force the UIImagePicker to only allow square images, but video length restriction requires allowsEditing - it is necessary to have 4 buttons when both images and videos are allowed for picking (2 for cameras and 2 for photo library)